### PR TITLE
feat: make the caseReference field required on new-deadline-submission

### DIFF
--- a/schemas/commands/new-deadline-submission.schema.json
+++ b/schemas/commands/new-deadline-submission.schema.json
@@ -5,7 +5,7 @@
 	"description": "A command to deliver metadata about a new document submission added to a deadline",
 	"type": "object",
 	"additionalProperties": true,
-	"required": ["name", "email", "deadline", "submissionType", "blobGuid", "documentName"],
+	"required": ["caseReference", "name", "email", "deadline", "submissionType", "blobGuid", "documentName"],
 	"properties": {
 		"caseReference": {
 			"type": "string",

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -2473,7 +2473,7 @@ export interface NewDeadlineSubmission {
   /**
    * The unique reference of the case
    */
-  caseReference?: string;
+  caseReference: string;
   /**
    * The name of the FO user who made the submission
    */


### PR DESCRIPTION
This is needed for the changes to the command handler in [APPLICS-847](https://pins-ds.atlassian.net/browse/APPLICS-847).

[APPLICS-847]: https://pins-ds.atlassian.net/browse/APPLICS-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ