### PR TITLE
fix: error on duplicate enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "commitlint": "commitlint --from=$(git rev-parse $(git cherry origin/main | head -n 1 | cut -c 3-)^1)",
     "gen": "npm run gen-docs && npm run gen-enums && npm run gen-types && npm run gen-cjs",
     "gen-docs": "node src/lib/gen-docs.js",
-    "gen-enums": "node src/lib/gen-enums.js",
+    "gen-enums": "node src/lib/gen-enums-run.js",
     "gen-types": "node src/lib/gen-types.js",
     "gen-cjs": "npx rollup ./src/index.js --file ./src/index.cjs --format cjs && npx rollup ./src/enums.js --file ./src/enums.cjs --format cjs",
     "lint": "npx eslint .",

--- a/src/lib/gen-enums-run.js
+++ b/src/lib/gen-enums-run.js
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import path from 'path';
+import url from 'url';
+import { loadAllSchemas } from '../index.js';
+import { loadSchema } from './load.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+export const constPath = path.join(__dirname, '..', 'enums.js');
+export const constTsPath = path.join(__dirname, '..', 'enums.d.ts');
+
+const NEW_LINE = '\n';
+
+import { collectEnumProps, generateConstants, schemaPrefix } from './gen-enums.js';
+
+/**
+ * Load all schemas and generate JS constant definitions
+ */
+async function run() {
+	const s = await loadAllSchemas();
+
+	/** @type {Object<string, string[]>} */
+	const enumProps = {};
+
+	for (const schemaName of Object.keys(s.schemas).sort()) {
+		const schema = s.schemas[schemaName];
+		collectEnumProps(enumProps, schema.properties, schemaPrefix(schemaName));
+	}
+
+	const staticEnums = await loadSchema(path.join(__dirname, 'enums-static.schema.json'));
+	collectEnumProps(enumProps, staticEnums.properties, 'message');
+
+	let output = '';
+	let tsOutput = '';
+
+	for (const name of Object.keys(enumProps).sort()) {
+		output += generateConstants(name, enumProps[name]) + NEW_LINE.repeat(2);
+		tsOutput += generateConstants(name, enumProps[name], { ts: true }) + NEW_LINE.repeat(2);
+	}
+
+	await fs.writeFile(constPath, output);
+	await fs.writeFile(constTsPath, tsOutput);
+}
+
+run().catch(console.error);

--- a/src/lib/gen-enums-run.js
+++ b/src/lib/gen-enums-run.js
@@ -42,4 +42,7 @@ async function run() {
 	await fs.writeFile(constTsPath, tsOutput);
 }
 
-run().catch(console.error);
+run().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/tests/src/gen-enums.test.js
+++ b/tests/src/gen-enums.test.js
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { collectEnumProps, formatName, generateConstants, schemaPrefix } from '../../src/lib/gen-enums.js';
+
+const normalizeWhitespace = (str) => str.replace(/\s+/g, '').trim();
+
+describe('gen-enums.js', () => {
+	describe('generateConstants', () => {
+		it('should generate JS code for exported constants', () => {
+			const name = 'TestEnum';
+			const values = ['value1', 'value2'];
+			const expectedOutput = `export const TEST_ENUM = Object.freeze({ VALUE_1: 'value1', VALUE_2: 'value2', });`;
+
+			const result = generateConstants(name, values);
+			assert.strictEqual(normalizeWhitespace(result), normalizeWhitespace(expectedOutput));
+		});
+
+		it('should generate TS code for exported constants', () => {
+			const name = 'TestEnum';
+			const values = ['value1', 'value2'];
+			const expectedOutput = `export const TEST_ENUM = { VALUE_1: 'value1', VALUE_2: 'value2', } as const;`;
+
+			const result = generateConstants(name, values, { ts: true });
+			assert.strictEqual(normalizeWhitespace(result), normalizeWhitespace(expectedOutput));
+		});
+
+		it('should handle empty values array', () => {
+			const name = 'EmptyEnum';
+			const values = [];
+			const expectedOutput = `export const EMPTY_ENUM = Object.freeze({});`;
+
+			const result = generateConstants(name, values);
+			assert.strictEqual(normalizeWhitespace(result), normalizeWhitespace(expectedOutput));
+		});
+
+		it('should sort values before generating constants', () => {
+			const name = 'UnsortedEnum';
+			const values = ['value2', 'value1'];
+			const expectedOutput = `export const UNSORTED_ENUM = Object.freeze({VALUE_1: 'value1', VALUE_2: 'value2',});`;
+
+			const result = generateConstants(name, values);
+			assert.strictEqual(normalizeWhitespace(result), normalizeWhitespace(expectedOutput));
+		});
+
+		it('should handle single value in the array', () => {
+			const name = 'SingleEnum';
+			const values = ['value1'];
+			const expectedOutput = `export const SINGLE_ENUM = Object.freeze({ VALUE_1: 'value1',});`;
+
+			const result = generateConstants(name, values);
+			assert.strictEqual(normalizeWhitespace(result), normalizeWhitespace(expectedOutput));
+		});
+	});
+
+	describe('formatName', () => {
+		it('should convert camelCase to UPPER_SNAKE_CASE', () => {
+			const result = formatName('camelCaseName');
+			assert.strictEqual(result, 'CAMEL_CASE_NAME');
+		});
+
+		it('should convert PascalCase to UPPER_SNAKE_CASE', () => {
+			const result = formatName('PascalCaseName');
+			assert.strictEqual(result, 'PASCAL_CASE_NAME');
+		});
+
+		it('should convert kebab-case to UPPER_SNAKE_CASE', () => {
+			const result = formatName('kebab-case-name');
+			assert.strictEqual(result, 'KEBAB_CASE_NAME');
+		});
+
+		it('should convert space separated words to UPPER_SNAKE_CASE', () => {
+			const result = formatName('space separated words');
+			assert.strictEqual(result, 'SPACE_SEPARATED_WORDS');
+		});
+
+		it('should handle single word input correctly', () => {
+			const result = formatName('word');
+			assert.strictEqual(result, 'WORD');
+		});
+
+		it('should handle empty string input correctly', () => {
+			const result = formatName('');
+			assert.strictEqual(result, '');
+		});
+
+		it('should handle already UPPER_SNAKE_CASE input correctly', () => {
+			const result = formatName('UPPER_SNAKE_CASE');
+			assert.strictEqual(result, 'UPPER_SNAKE_CASE');
+		});
+	});
+
+	describe('collectEnumProps', () => {
+		it('builds enums', () => {
+			const map = {};
+			collectEnumProps(map, { testSchema: { type: 'string', enum: ['test'] } }, 'testPrefix');
+			assert.deepStrictEqual(map, { testPrefix_testSchema: ['test'] });
+			collectEnumProps(map, { testSchema2: { type: 'string', enum: ['test2'] } }, 'testPrefix');
+			assert.deepStrictEqual(map, { testPrefix_testSchema: ['test'], testPrefix_testSchema2: ['test2'] });
+		});
+
+		it('reduces duplicate enums', () => {
+			const map = {};
+			collectEnumProps(map, { testSchema: { type: 'string', enum: ['test'] } }, 'testPrefix');
+			assert.deepStrictEqual(map, { testPrefix_testSchema: ['test'] });
+			collectEnumProps(map, { testSchema: { type: 'string', enum: ['test'] } }, 'testPrefix');
+			assert.deepStrictEqual(map, { testPrefix_testSchema: ['test'] });
+		});
+
+		it('errors for mismatched enums', () => {
+			const map = {};
+			collectEnumProps(map, { testSchema: { type: 'string', enum: ['test'] } }, 'testPrefix');
+			assert.throws(
+				() => collectEnumProps(map, { testSchema: { type: 'string', enum: ['test', 'test2'] } }, 'testPrefix'),
+				{
+					message: 'testPrefix_testSchema already has an enum'
+				}
+			);
+		});
+	});
+
+	describe('schemaPrefix', () => {
+		it('should return "appeal" when schemaName contains "appeal"', () => {
+			const result = schemaPrefix('AppealCase');
+			assert.strictEqual(result, 'appeal');
+		});
+
+		it('should return "nsip" when schemaName contains "nsip"', () => {
+			const result = schemaPrefix('NsipProject');
+			assert.strictEqual(result, 'nsip');
+		});
+
+		it('should return undefined when schemaName does not contain "appeal" or "nsip"', () => {
+			const result = schemaPrefix('OtherSchema');
+			assert.strictEqual(result, undefined);
+		});
+
+		it('should handle mixed case schema names correctly', () => {
+			const result = schemaPrefix('ApPeAlCase');
+			assert.strictEqual(result, 'appeal');
+		});
+
+		it('should return undefined for an empty string', () => {
+			const result = schemaPrefix('');
+			assert.strictEqual(result, undefined);
+		});
+
+		it('should return undefined for random string', () => {
+			const result = schemaPrefix('randomString');
+			assert.strictEqual(result, undefined);
+		});
+	});
+});


### PR DESCRIPTION
We have an issue with an enum generation
If an enum is declared via the same name across schemas they will overwrite each other
Many of them have the same values so have no issue _currently_
2 enums do have issues and overwrite an existing enum with different values:
- APPEAL_CASE_STATUS
- NSIP_SOURCE_SYSTEM

This PR causes the script to throw an error if a duplicate enum has different values from the existing enum
This will lead to a pipeline failure blocking a change that causes this issue

However this cannot be merged until the two enums above are resolved - they will need either different names or to be given the same values