### PR TITLE
fix(appeals): use unique command names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pins-data-model",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pins-data-model",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pins-data-model",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "JSON Schemas for the Planning Inspectorate's Data Model",
   "main": "src/index.js",
   "type": "module",

--- a/schemas/commands/appeal-common-submission.schema.json
+++ b/schemas/commands/appeal-common-submission.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "commands/appeal-common.schema.json",
+  "$id": "commands/appeal-common-submission.schema.json",
   "title": "Appellant common submission properties",
   "description": "Schema defining any properties common across all appeal types for appeal submissions",
   "type": "object",

--- a/schemas/commands/appeal-has-submission.schema.json
+++ b/schemas/commands/appeal-has-submission.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "commands/appeal-has.schema.json",
+  "$id": "commands/appeal-has-submission.schema.json",
   "title": "Appellant HAS submission properties",
   "description": "Schema defining any HAS specific properties for submissions",
   "type": "object",
@@ -20,7 +20,7 @@
     "appellantCostsAppliedFor"
   ],
   "allOf": [
-    { "$ref": "appeal-common.schema.json"},
+    { "$ref": "appeal-common-submission.schema.json"},
     {
       "properties": {
         "isGreenBelt": {

--- a/schemas/commands/appeal-s78-submission.schema.json
+++ b/schemas/commands/appeal-s78-submission.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "commands/appeal-s78.schema.json",
+  "$id": "commands/appeal-s78-submission.schema.json",
   "title": "Appellant s78 submission properties",
   "description": "Schema defining any S78 specific properties for questionnaire submissions",
   "type": "object",
@@ -18,7 +18,7 @@
     "statusPlanningObligation"
   ],
   "allOf": [
-    { "$ref": "appeal-has.schema.json"},
+    { "$ref": "appeal-has-submission.schema.json"},
     {
       "properties": {
         "agriculturalHolding": {

--- a/schemas/commands/appellant-submission.schema.json
+++ b/schemas/commands/appellant-submission.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "appellant-submission.schema.json",
+  "$id": "commands/appellant-submission.schema.json",
   "title": "Appellant Submission Command",
   "description": "Schema defining the data produced by the Front-Office when an appeal is requested",
   "$comment": "This is a combination of Appeal, Documents and Service user data",
@@ -19,11 +19,11 @@
       "oneOf": [
         { "allOf": [
           {"properties": { "caseType": { "const": "D" } }},
-          { "$ref": "appeal-has.schema.json"}
+          { "$ref": "appeal-has-submission.schema.json"}
         ]},
         { "allOf": [
           {"properties": { "caseType": { "const": "W" } }},
-          { "$ref": "appeal-s78.schema.json"}
+          { "$ref": "appeal-s78-submission.schema.json"}
         ]}
       ]
     },

--- a/schemas/commands/lpa-questionnaire.schema.json
+++ b/schemas/commands/lpa-questionnaire.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "lpa-questionnaire.schema.json",
+  "$id": "commands/lpa-questionnaire.schema.json",
   "title": "LPA Questionnaire Command",
   "description": "Schema defining the data produced by the Front-Office when an LPA Questionnaire is submitted",
   "$comment": "This is a combination of an LPA Questionnaire and Documents",

--- a/src/gen-types.js
+++ b/src/gen-types.js
@@ -28,7 +28,7 @@ async function run() {
     for (const commandName of Object.keys(s.commands).sort()) {
         const schema = s.commands[commandName];
         
-        if (commandName.startsWith('appeal') || commandName.startsWith('lpa-questionnaire')) {
+        if (commandName.startsWith('appeal') || commandName.startsWith('appellant') || commandName.startsWith('lpa-questionnaire')) {
             // hack to allow nested $ref links to function in tests and gen types,
             // can we leverage a better means to resolve $refs that aligns with how tests/appeals references this 
             types += await compile(schema, schema['$id'], options(first, commandsPath));

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -3062,16 +3062,115 @@ export interface AppellantCommonSubmissionProperties {
 }
 
 /**
+ * Schema defining any HAS specific properties for submissions
+ */
+export type AppellantHASSubmissionProperties = AppellantCommonSubmissionProperties & {
+  /**
+   * Indicates if the site is in a green belt
+   */
+  isGreenBelt?: boolean | null;
+  /**
+   * The site area, in square meters
+   */
+  siteAreaSquareMetres?: number | null;
+  /**
+   * The floor space, in square meters
+   */
+  floorSpaceSquareMetres?: number | null;
+  /**
+   * Indicates if the appellant has complete ownership of the site
+   */
+  ownsAllLand?: boolean | null;
+  /**
+   * Indicates if the appellant has partial ownership of the site
+   */
+  ownsSomeLand?: boolean | null;
+  /**
+   * Indicates if the appellant knows other owners of the site
+   */
+  knowsOtherOwners?: 'Yes' | 'No' | 'Some' | null;
+  /**
+   * Indicates if the appellant knows all owners of the site
+   */
+  knowsAllOwners?: 'Yes' | 'No' | 'Some' | null;
+  /**
+   * Indicates if the appellant has advertised the appeal to the LPA decision
+   */
+  advertisedAppeal?: boolean | null;
+  /**
+   * Indicates if the appellant has informed other owners of the site
+   */
+  ownersInformed?: boolean | null;
+  /**
+   * The original description of the development, as provided by the appellant
+   */
+  originalDevelopmentDescription?: string | null;
+  /**
+   * Indicates that the LPA has changed the development description
+   */
+  changedDevelopmentDescription?: boolean | null;
+  /**
+   * Indicates if the appellant has applied for costs
+   */
+  appellantCostsAppliedFor?: boolean | null;
+};
+/**
+ * Schema defining any S78 specific properties for questionnaire submissions
+ */
+export type AppellantS78SubmissionProperties = AppellantHASSubmissionProperties & {
+  /**
+   * Indicates if the site is an agricultural holding
+   */
+  agriculturalHolding?: boolean | null;
+  /**
+   * Indicates if the site is a tenant agricultural holding
+   */
+  tenantAgriculturalHolding?: boolean | null;
+  /**
+   * Indicates if the site is an agricultural holding with other tenants
+   */
+  otherTenantsAgriculturalHolding?: boolean | null;
+  /**
+   * If the site is an agricultural holding, indicates tenants are informed
+   */
+  informedTenantsAgriculturalHolding?: boolean | null;
+  /**
+   * The procedure preference indicated by the appellant
+   */
+  appellantProcedurePreference?: 'written' | 'hearing' | 'inquiry' | null;
+  /**
+   * The procedure details preference indicated by the appellant
+   */
+  appellantProcedurePreferenceDetails?: string | null;
+  /**
+   * The duration of the procedure indicated by the appellant
+   */
+  appellantProcedurePreferenceDuration?: number | null;
+  /**
+   * The number of witnesses in inquiries
+   */
+  inquiryHowManyWitnesses?: number | null;
+  /**
+   * Indicates the existence of a planning obligation
+   */
+  planningObligation?: boolean | null;
+  /**
+   * The planning obligation information, if available
+   */
+  statusPlanningObligation?: string | null;
+};
+
+/**
  * Schema defining the data produced by the Front-Office when an appeal is requested
  */
 export interface AppellantSubmissionCommand {
   casedata:
     | ({
         caseType?: 'D';
-      } & AppealHASCase)
+      } & AppellantHASSubmissionProperties)
     | ({
         caseType?: 'W';
-      } & AppealS78Case);
+      } & AppellantS78SubmissionProperties);
   documents: {
     /**
      * The unique identifier for the document
@@ -3187,40 +3286,13 @@ export interface AppellantSubmissionCommand {
   [k: string]: unknown;
 }
 /**
- * Schema defining the metadata for an appeal
+ * Schema defining any properties common across all appeal types for appeal submissions
  */
-export interface AppealHASCase {
-  /**
-   * Internal case identifier
-   */
-  caseId: number | null;
-  /**
-   * External case identifier
-   */
-  caseReference: string;
+export interface AppellantCommonSubmissionProperties {
   /**
    * Case submission id - link to draft submission created by appellant
    */
-  submissionId?: string | null;
-  /**
-   * The processing status for the appeal
-   */
-  caseStatus:
-    | 'assign_case_officer'
-    | 'validation'
-    | 'ready_to_start'
-    | 'lpa_questionnaire'
-    | 'issue_determination'
-    | 'complete'
-    | 'invalid'
-    | 'closed'
-    | 'withdrawn'
-    | 'awaiting_transfer'
-    | 'transferred';
-  /**
-   * The internal code for an appeal type, e.g. D (Householder)
-   */
-  caseType: 'C' | 'D' | 'F' | 'G' | 'H' | 'L' | 'Q' | 'S' | 'V' | 'W' | 'X' | 'Y' | 'Z';
+  submissionId: string;
   /**
    * The type of procedure for the appeal
    */
@@ -3230,137 +3302,9 @@ export interface AppealHASCase {
    */
   lpaCode: string;
   /**
-   * Unique identifier for the case officer assigned to the case
-   */
-  caseOfficerId: string | null;
-  /**
-   * Unique identifier for the inspector assigned to the case
-   */
-  inspectorId: string | null;
-  /**
-   * A level used for allocation purposes
-   */
-  allocationLevel: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | null;
-  /**
-   * A band used for allocation purposes
-   */
-  allocationBand: 1 | 2 | 3 | null;
-  /**
-   * A list of specialisms for allocation purposes
-   */
-  caseSpecialisms: string[] | null;
-  /**
    * The date the appeal was submitted by the appellant
    */
   caseSubmittedDate: string;
-  /**
-   * The date the appeal was received
-   */
-  caseCreatedDate: string;
-  /**
-   * The date the appeal was last updated in the back-office
-   */
-  caseUpdatedDate: string;
-  /**
-   * The date since when the appeal was considered valid
-   */
-  caseValidDate: string | null;
-  /**
-   * The date the appeal was validated in the back-office
-   */
-  caseValidationDate: string | null;
-  /**
-   * The outcome of the validation action
-   */
-  caseValidationOutcome: 'valid' | 'invalid' | 'incomplete' | null;
-  /**
-   * A list of reasons why the appeal is invalid
-   */
-  caseValidationInvalidDetails: string[] | null;
-  /**
-   * A list of reasons why the appeal is incomplete
-   */
-  caseValidationIncompleteDetails: string[] | null;
-  /**
-   * When the validation outcome is incomplete, an extension may be granted to provide missing information
-   */
-  caseExtensionDate: string | null;
-  /**
-   * A date indicating when the case was started, resulting in the creation of a timetable
-   */
-  caseStartedDate: string | null;
-  /**
-   * A date indicating when the case was published
-   */
-  casePublishedDate: string | null;
-  /**
-   * Indicates if the case is linked, and the type of relationship
-   */
-  linkedCaseStatus: 'lead' | 'child' | null;
-  /**
-   * The reference of the lead case, if the case is a child case
-   */
-  leadCaseReference: string | null;
-  /**
-   * If the case is started and has a timetable, a deadline for the LPA to provide a response
-   */
-  lpaQuestionnaireDueDate: string | null;
-  /**
-   * The date the LPA provided a response to the case
-   */
-  lpaQuestionnaireSubmittedDate: string | null;
-  /**
-   * The date the LPA response was receeived
-   */
-  lpaQuestionnaireCreatedDate: string | null;
-  /**
-   * The date indicating when the questionnaire review was completed and the questionnaire published
-   */
-  lpaQuestionnairePublishedDate: string | null;
-  /**
-   * The outcome of the validation action
-   */
-  lpaQuestionnaireValidationOutcome: 'complete' | 'incomplete' | null;
-  /**
-   * The date the LPA response was validated
-   */
-  lpaQuestionnaireValidationOutcomeDate: string | null;
-  /**
-   * A list of reasons why the questionnaire is incomplete
-   */
-  lpaQuestionnaireValidationDetails: string[] | null;
-  /**
-   * A statement provided by the LPA
-   */
-  lpaStatement: string | null;
-  /**
-   * The date the appeal was withdrawn by the appellant
-   */
-  caseWithdrawnDate: string | null;
-  /**
-   * The date the appeal was transferred to a new case of a different type
-   */
-  caseTransferredDate: string | null;
-  /**
-   * The date the appeal was closed and the appellant requested to resubmit
-   */
-  transferredCaseClosedDate: string | null;
-  /**
-   * The date of the appeal decision
-   */
-  caseDecisionOutcomeDate: string | null;
-  /**
-   * The date the appeal decision was published
-   */
-  caseDecisionPublishedDate: string | null;
-  /**
-   * The final outcome for the decision
-   */
-  caseDecisionOutcome: 'allowed' | 'split_decision' | 'dismissed' | 'invalid' | null;
-  /**
-   * The date the appeal decision letter
-   */
-  caseCompletedDate: string | null;
   /**
    * Indicates if an enforcement notice is the reason for the appeal
    */
@@ -3414,70 +3358,6 @@ export interface AppealHASCase {
    */
   siteSafetyDetails: string[] | null;
   /**
-   * The site area, in square meters
-   */
-  siteAreaSquareMetres: number | null;
-  /**
-   * The floor space, in square meters
-   */
-  floorSpaceSquareMetres: number | null;
-  /**
-   * Indicates if the LPA considers the appeal type appropriate
-   */
-  isCorrectAppealType: boolean | null;
-  /**
-   * Indicates if the site is in a green belt
-   */
-  isGreenBelt: boolean | null;
-  /**
-   * Indicates if the site is in a conservation area
-   */
-  inConservationArea: boolean | null;
-  /**
-   * Indicates if the appellant has complete ownership of the site
-   */
-  ownsAllLand: boolean | null;
-  /**
-   * Indicates if the appellant has partial ownership of the site
-   */
-  ownsSomeLand: boolean | null;
-  /**
-   * Indicates if the appellant knows other owners of the site
-   */
-  knowsOtherOwners: 'Yes' | 'No' | 'Some' | null;
-  /**
-   * Indicates if the appellant knows all owners of the site
-   */
-  knowsAllOwners: 'Yes' | 'No' | 'Some' | null;
-  /**
-   * Indicates if the appellant has advertised the appeal to the LPA decision
-   */
-  advertisedAppeal: boolean | null;
-  /**
-   * The methods used to notify relevant parties
-   */
-  notificationMethod: ('notice' | 'letter' | 'advert' | null)[] | null;
-  /**
-   * Indicates if the appellant has informed other owners of the site
-   */
-  ownersInformed: boolean | null;
-  /**
-   * The original description of the development, as provided by the appellant
-   */
-  originalDevelopmentDescription: string | null;
-  /**
-   * Indicates that the LPA has changed the development description
-   */
-  changedDevelopmentDescription: boolean | null;
-  /**
-   * New conditions details provided by the LPA
-   */
-  newConditionDetails: string | null;
-  /**
-   * A list of related case references known to the appellant and the LPA
-   */
-  nearbyCaseReferences: string[] | null;
-  /**
    * A list of neighbouring site addresses
    */
   neighbouringSiteAddresses:
@@ -3514,537 +3394,9 @@ export interface AppealHASCase {
       }[]
     | null;
   /**
-   * A list of affected listed building IDs from Historic England
-   */
-  affectedListedBuildingNumbers: string[] | null;
-  /**
-   * Indicates if the appellant has applied for costs
-   */
-  appellantCostsAppliedFor: boolean | null;
-  /**
-   * Indicates if the appellant has applied for costs
-   */
-  lpaCostsAppliedFor: boolean | null;
-  [k: string]: unknown;
-}
-/**
- * Schema defining the metadata for an appeal (S78)
- */
-export interface AppealS78Case {
-  /**
-   * Internal case identifier
-   */
-  caseId: number | null;
-  /**
-   * External case identifier
-   */
-  caseReference: string;
-  /**
-   * Case submission id - link to draft submission created by appellant
-   */
-  submissionId?: string | null;
-  /**
-   * The processing status for the appeal
-   */
-  caseStatus:
-    | 'assign_case_officer'
-    | 'validation'
-    | 'ready_to_start'
-    | 'lpa_questionnaire'
-    | 'issue_determination'
-    | 'statements'
-    | 'evidence'
-    | 'witnesses'
-    | 'final_comments'
-    | 'complete'
-    | 'invalid'
-    | 'closed'
-    | 'withdrawn'
-    | 'awaiting_transfer'
-    | 'transferred';
-  /**
-   * The internal code for an appeal type, e.g. D (Householder)
-   */
-  caseType: 'C' | 'D' | 'F' | 'G' | 'H' | 'L' | 'Q' | 'S' | 'V' | 'W' | 'X' | 'Y' | 'Z';
-  /**
-   * The type of procedure for the appeal
-   */
-  caseProcedure: 'written' | 'hearing' | 'inquiry' | null;
-  /**
-   * A unique identifier for the Local Planning Authority
-   */
-  lpaCode: string;
-  /**
-   * Unique identifier for the case officer assigned to the case
-   */
-  caseOfficerId: string | null;
-  /**
-   * Unique identifier for the inspector assigned to the case
-   */
-  inspectorId: string | null;
-  /**
-   * A level used for allocation purposes
-   */
-  allocationLevel: 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | null;
-  /**
-   * A band used for allocation purposes
-   */
-  allocationBand: 1 | 2 | 3 | null;
-  /**
-   * A list of specialisms for allocation purposes
-   */
-  caseSpecialisms: string[] | null;
-  /**
-   * The date the appeal was submitted by the appellant
-   */
-  caseSubmittedDate: string;
-  /**
-   * The date the appeal was received
-   */
-  caseCreatedDate: string;
-  /**
-   * The date the appeal was last updated in the back-office
-   */
-  caseUpdatedDate: string;
-  /**
-   * The date since when the appeal was considered valid
-   */
-  caseValidDate: string | null;
-  /**
-   * The date the appeal was validated in the back-office
-   */
-  caseValidationDate: string | null;
-  /**
-   * The outcome of the validation action
-   */
-  caseValidationOutcome: 'valid' | 'invalid' | 'incomplete' | null;
-  /**
-   * A list of reasons why the appeal is invalid
-   */
-  caseValidationInvalidDetails: string[] | null;
-  /**
-   * A list of reasons why the appeal is incomplete
-   */
-  caseValidationIncompleteDetails: string[] | null;
-  /**
-   * When the validation outcome is incomplete, an extension may be granted to provide missing information
-   */
-  caseExtensionDate: string | null;
-  /**
-   * A date indicating when the case was started, resulting in the creation of a timetable
-   */
-  caseStartedDate: string | null;
-  /**
-   * A date indicating when the case was published
-   */
-  casePublishedDate: string | null;
-  /**
-   * Indicates if the case is linked, and the type of relationship
-   */
-  linkedCaseStatus: 'lead' | 'child' | null;
-  /**
-   * The reference of the lead case, if the case is a child case
-   */
-  leadCaseReference: string | null;
-  /**
-   * If the case is started and has a timetable, a deadline for the LPA to provide a response
-   */
-  lpaQuestionnaireDueDate: string | null;
-  /**
-   * The date the LPA provided a response to the case
-   */
-  lpaQuestionnaireSubmittedDate: string | null;
-  /**
-   * The date the LPA response was receeived
-   */
-  lpaQuestionnaireCreatedDate: string | null;
-  /**
-   * The date indicating when the questionnaire review was completed and the questionnaire published
-   */
-  lpaQuestionnairePublishedDate: string | null;
-  /**
-   * The outcome of the validation action
-   */
-  lpaQuestionnaireValidationOutcome: 'complete' | 'incomplete' | null;
-  /**
-   * The date the LPA response was validated
-   */
-  lpaQuestionnaireValidationOutcomeDate: string | null;
-  /**
-   * A list of reasons why the questionnaire is incomplete
-   */
-  lpaQuestionnaireValidationDetails: string[] | null;
-  /**
-   * A statement provided by the LPA
-   */
-  lpaStatement: string | null;
-  /**
-   * The date the appeal was withdrawn by the appellant
-   */
-  caseWithdrawnDate: string | null;
-  /**
-   * The date the appeal was transferred to a new case of a different type
-   */
-  caseTransferredDate: string | null;
-  /**
-   * The date the appeal was closed and the appellant requested to resubmit
-   */
-  transferredCaseClosedDate: string | null;
-  /**
-   * The date of the appeal decision
-   */
-  caseDecisionOutcomeDate: string | null;
-  /**
-   * The date the appeal decision was published
-   */
-  caseDecisionPublishedDate: string | null;
-  /**
-   * The final outcome for the decision
-   */
-  caseDecisionOutcome: 'allowed' | 'split_decision' | 'dismissed' | 'invalid' | null;
-  /**
-   * The date the appeal decision letter
-   */
-  caseCompletedDate: string | null;
-  /**
-   * Indicates if an enforcement notice is the reason for the appeal
-   */
-  enforcementNotice: boolean | null;
-  /**
-   * The unique identifier of the LPA application
-   */
-  applicationReference: string;
-  /**
-   * The date of the original LPA application
-   */
-  applicationDate: string;
-  /**
-   * The outcome of the original LPA decision
-   */
-  applicationDecision: 'granted' | 'refused' | 'not_received';
-  /**
-   * The date of the original LPA decision
-   */
-  applicationDecisionDate: string | null;
-  /**
-   * The statutory deadline for submitting an appeal from the original LPA decision date
-   */
-  caseSubmissionDueDate: string | null;
-  /**
-   * First line of address for the appeal site
-   */
-  siteAddressLine1: string;
-  /**
-   * Second line of address for the appeal site
-   */
-  siteAddressLine2: string | null;
-  /**
-   * Town / City of the site address
-   */
-  siteAddressTown: string;
-  /**
-   * County of the site address
-   */
-  siteAddressCounty: string | null;
-  /**
-   * Postal code of the site address
-   */
-  siteAddressPostcode: string;
-  /**
-   * Provided information on site accessibility
-   */
-  siteAccessDetails: string[] | null;
-  /**
-   * Provided information on site health and safety
-   */
-  siteSafetyDetails: string[] | null;
-  /**
-   * The site area, in square meters
-   */
-  siteAreaSquareMetres: number | null;
-  /**
-   * The floor space, in square meters
-   */
-  floorSpaceSquareMetres: number | null;
-  /**
-   * Indicates if the LPA considers the appeal type appropriate
-   */
-  isCorrectAppealType: boolean | null;
-  /**
-   * Indicates if the site is in a green belt
-   */
-  isGreenBelt: boolean | null;
-  /**
-   * Indicates if the site is in a conservation area
-   */
-  inConservationArea: boolean | null;
-  /**
-   * Indicates if the appellant has complete ownership of the site
-   */
-  ownsAllLand: boolean | null;
-  /**
-   * Indicates if the appellant has partial ownership of the site
-   */
-  ownsSomeLand: boolean | null;
-  /**
-   * Indicates if the appellant knows other owners of the site
-   */
-  knowsOtherOwners: 'Yes' | 'No' | 'Some' | null;
-  /**
-   * Indicates if the appellant knows all owners of the site
-   */
-  knowsAllOwners: 'Yes' | 'No' | 'Some' | null;
-  /**
-   * Indicates if the appellant has advertised the appeal to the LPA decision
-   */
-  advertisedAppeal: boolean | null;
-  /**
-   * The methods used to notify relevant parties
-   */
-  notificationMethod: ('notice' | 'letter' | 'advert' | null)[] | null;
-  /**
-   * Indicates if the appellant has informed other owners of the site
-   */
-  ownersInformed: boolean | null;
-  /**
-   * The original description of the development, as provided by the appellant
-   */
-  originalDevelopmentDescription: string | null;
-  /**
-   * Indicates that the LPA has changed the development description
-   */
-  changedDevelopmentDescription: boolean | null;
-  /**
-   * New conditions details provided by the LPA
-   */
-  newConditionDetails: string | null;
-  /**
    * A list of related case references known to the appellant and the LPA
    */
   nearbyCaseReferences: string[] | null;
-  /**
-   * A list of neighbouring site addresses
-   */
-  neighbouringSiteAddresses:
-    | {
-        /**
-         * First line of address of the site
-         */
-        neighbouringSiteAddressLine1: string;
-        /**
-         * Second line of address of the site
-         */
-        neighbouringSiteAddressLine2: string | null;
-        /**
-         * Town / City of the site address
-         */
-        neighbouringSiteAddressTown: string;
-        /**
-         * County of the site address
-         */
-        neighbouringSiteAddressCounty: string | null;
-        /**
-         * Postal code of the site address
-         */
-        neighbouringSiteAddressPostcode: string;
-        /**
-         * Provided information on site accessibility on this address
-         */
-        neighbouringSiteAccessDetails: string | null;
-        /**
-         * Provided information on site health and safety on this address
-         */
-        neighbouringSiteSafetyDetails: string | null;
-        [k: string]: unknown;
-      }[]
-    | null;
-  /**
-   * A list of affected listed building IDs from Historic England
-   */
-  affectedListedBuildingNumbers: string[] | null;
-  /**
-   * A list of changed listed building IDs from Historic England
-   */
-  changedListedBuildingNumbers: string[] | null;
-  /**
-   * Indicates if the appellant has applied for costs
-   */
-  appellantCostsAppliedFor: boolean | null;
-  /**
-   * Indicates if the appellant has applied for costs
-   */
-  lpaCostsAppliedFor: boolean | null;
-  /**
-   * Indicates if the site is an agricultural holding
-   */
-  agriculturalHolding: boolean | null;
-  /**
-   * Indicates if the site is a tenant agricultural holding
-   */
-  tenantAgriculturalHolding: boolean | null;
-  /**
-   * Indicates if the site is an agricultural holding with other tenants
-   */
-  otherTenantsAgriculturalHolding: boolean | null;
-  /**
-   * If the site is an agricultural holding, indicates tenants are informed
-   */
-  informedTenantsAgriculturalHolding: boolean | null;
-  /**
-   * The procedure preference indicated by the appellant
-   */
-  appellantProcedurePreference: 'written' | 'hearing' | 'inquiry' | null;
-  /**
-   * The procedure details preference indicated by the appellant
-   */
-  appellantProcedurePreferenceDetails: string | null;
-  /**
-   * The duration of the procedure indicated by the appellant
-   */
-  appellantProcedurePreferenceDuration: number | null;
-  /**
-   * The number of witnesses appellant has suggested for inquiries preference
-   */
-  appellantProcedurePreferenceWitnessCount: number | null;
-  /**
-   * The planning obligation information, if available
-   */
-  statusPlanningObligation: string | null;
-  /**
-   * Indicates that a scheduled monument is affected
-   */
-  affectsScheduledMonument: boolean | null;
-  /**
-   * Indicates the existence of protected species
-   */
-  hasProtectedSpecies: boolean | null;
-  /**
-   * Indicates an area of outstanding beauty (National Landscape)
-   */
-  isAonbNationalLandscape: boolean | null;
-  /**
-   * The designated site names
-   */
-  designatedSitesNames: string[] | null;
-  /**
-   * Indicates a traveller site
-   */
-  isGypsyOrTravellerSite: boolean | null;
-  /**
-   * Indicates a PROW (public right of way)
-   */
-  isPublicRightOfWay: boolean | null;
-  /**
-   * The impact schedule from EIA
-   */
-  eiaEnvironmentalImpactSchedule: 'schedule-1' | 'schedule-2' | null;
-  /**
-   * The development description from EIA
-   */
-  eiaDevelopmentDescription:
-    | 'agriculture-aquaculture'
-    | 'change-extensions'
-    | 'chemical-industry'
-    | 'energy-industry'
-    | 'extractive-industry'
-    | 'food-industry'
-    | 'infrastructure-projects'
-    | 'mineral-industry'
-    | 'other-projects'
-    | 'production-processing-of-metals'
-    | 'rubber-industry'
-    | 'textile-industries'
-    | 'tourism-leisure'
-    | null;
-  /**
-   * The sensitive area details from EIA
-   */
-  eiaSensitiveAreaDetails: string | null;
-  /**
-   * EIA specific threshold
-   */
-  eiaColumnTwoThreshold: boolean | null;
-  /**
-   * EIA screening opinion
-   */
-  eiaScreeningOpinion: boolean | null;
-  /**
-   * EIA environmental statement required
-   */
-  eiaRequiresEnvironmentalStatement: boolean | null;
-  /**
-   * EIA completed environmental statement required
-   */
-  eiaCompletedEnvironmentalStatement: boolean | null;
-  /**
-   * The details of the bodies consulted by EIA
-   */
-  eiaConsultedBodiesDetails: string | null;
-  /**
-   * Indicates statutory consultees
-   */
-  hasStatutoryConsultees: boolean | null;
-  /**
-   * Indicates the existence of an infrastructure levy
-   */
-  hasInfrastructureLevy: boolean | null;
-  /**
-   * Indicates if the infrastructure levy is formally adopted
-   */
-  isInfrastructureLevyFormallyAdopted: boolean | null;
-  /**
-   * The date of the infrastructure levy adoption
-   */
-  infrastructureLevyAdoptedDate: string | null;
-  /**
-   * The expected date of the infrastructure levy
-   */
-  infrastructureLevyExpectedDate: string | null;
-  /**
-   * The procedure preference indicated by the LPA
-   */
-  lpaProcedurePreference: 'written' | 'hearing' | 'inquiry' | null;
-  /**
-   * The procedure details preference indicated by the LPA
-   */
-  lpaProcedurePreferenceDetails: string | null;
-  /**
-   * The duration of enquiry indicated by the LPA
-   */
-  lpaProcedurePreferenceDuration: number | null;
-  caseworkReason: string | null;
-  developmentType: string | null;
-  importantInformation: string | null;
-  jurisdiction: string | null;
-  redeterminedIndicator: string | null;
-  /**
-   * The date of the cost report
-   */
-  dateCostsReportDespatched: string | null;
-  dateNotRecoveredOrDerecovered: string | null;
-  dateRecovered: string | null;
-  originalCaseDecisionDate: string | null;
-  targetDate: string | null;
-  appellantCommentsSubmittedDate: string | null;
-  appellantStatementSubmittedDate: string | null;
-  finalCommentsDueDate: string | null;
-  interestedPartyRepsDueDate: string | null;
-  lpaCommentsSubmittedDate: string | null;
-  lpaProofsSubmittedDate: string | null;
-  lpaStatementSubmittedDate: string | null;
-  proofsOfEvidenceDueDate: string | null;
-  siteNoticesSentDate: string | null;
-  statementDueDate: string | null;
-  reasonForNeighbourVisits: string | null;
-  /**
-   * The net gain in residences of the proposed development
-   */
-  numberOfResidencesNetChange: number | null;
-  siteGridReferenceEasting: string | null;
-  siteGridReferenceNorthing: string | null;
-  siteViewableFromRoad: boolean | null;
-  siteWithinSSSI: boolean | null;
-  typeOfPlanningApplication: string | null;
   [k: string]: unknown;
 }
 


### PR DESCRIPTION
Use unique command names in case any downstream users are reliant on this
Fixes issue with type being generated wrong for appellant submission