### PR TITLE
test: crudely check schema names are singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ JSON Schemas for the Planning Inspectorate's Data Model.
 All messages over the enterprise service bus are in Data Model compliant formats, the schema's in this repository defined those formats.
 
 ## Rules of engagement
+* Schema names should use the singular form (for example, `service-user` rather than `service-users`).
 * Messages broadcast over the service bus must be pre-validated against the schema.
 * Each service bus topic corresponds to one schema. 
 * Each message encompasses the complete state of an entity (as defined by [ECST](https://blogs.mulesoft.com/api-integration/strategy/event-carried-state-messages/)) and does not delineate specific changes (the delta). 

--- a/tests/schemas.test.js
+++ b/tests/schemas.test.js
@@ -65,4 +65,29 @@ describe('schemas', () => {
             throw new Error(`${Object.keys(errorsBySchema).join(', ')} schemas have mismatched $id and filenames (count: ${Object.keys(errorsBySchema).length}), see console output`);
         }
     });
+    it('should use the singular form for $id', () => {
+        // very crude test to ensure schemas don't end in 's'...
+        const suffixExceptions = [
+            'has', // allow has suffix for appeals
+            'listed-buildings' // allow this temporary schema, to remove when this schema copy is removed
+        ];
+
+        const allSchemas = loadAllSchemasSync();
+        const schemas = Object.values(allSchemas).reduce((a, c) => ({ ...a, ...c }), {});
+        const errors = [];
+        for (const schema of Object.values(schemas)) {
+            const name = schema.$id.replace('.schema.json', '');
+            if (name.endsWith('s') && !suffixExceptions.some(suffix => name.endsWith(suffix))) {
+                errors.push(schema.$id);
+            }
+        }
+        if (errors.length > 0) {
+            console.log('*'.repeat(50));
+            console.log('ERRORS:');
+            for (const error of errors) {
+                console.log('  ' + error);
+            }
+            throw new Error(`${errors.join(', ')} schemas use plural names, see console output`);
+        }
+    });
 });


### PR DESCRIPTION
Crudely enforce singular names for schemas, with exceptions

https://pins-ds.atlassian.net/browse/RDSD-134