### PR TITLE
task: auto tag with pipeline

### DIFF
--- a/.azure/tag.yml
+++ b/.azure/tag.yml
@@ -1,0 +1,29 @@
+trigger:
+  branches:
+    include:
+      - main
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      endpoint: Planning-Inspectorate
+      name: Planning-Inspectorate/common-pipeline-templates
+      ref: refs/tags/release/3.18.2
+
+extends:
+  template: stages/wrapper_ci.yml@templates
+  parameters:
+    skipAzureAuth: true
+    validationJobs:
+      - name: Tag
+        steps:
+          - script: |
+              VERSION=$(jq -r .version package-lock.json)
+              if git tag -l "$VERSION" | grep -q "$VERSION"; then
+                echo "tag already exists: $VERSION"
+              else
+                git tag -a "$VERSION" -m "Release version $VERSION"
+                git push origin "$VERSION"
+              fi
+        displayName: Auto git tag version with version in npm

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/README.md
+++ b/README.md
@@ -223,10 +223,20 @@ and generate a cjs version:
 `npm run gen-cjs`
 
 
-and also tag the repo with a new version (format TBC).
-
-> todo: run this on pre-commit or on a pipeline
-
 It is also important to update the Python pydantic models, by running:
 
 `python pins_data_model/gen_models.py`
+
+
+## Release tags
+
+Update the npm version and the tag.yml pipeline will git tag it for you after merging with main
+
+Use:
+
+`npm version patch`
+`npm version minor`
+`npm version major`
+`npm version 1.2.3`
+
+> todo: we could remove this manual step by using semantic release + enforced commit formats


### PR DESCRIPTION
Auto tag with in pipeline if npm version is updated
Will only handle 1 tag per PR merge
Will conflict after each PR
`git-tag-version=false` so that the pipeline can handle git tag on main
Can improve this with semantic release but that seems more of a pain to setup