### PR TITLE
feat: allow appellant-submission and lpaq for cas planning

### DIFF
--- a/schemas/commands/appellant-submission.schema.json
+++ b/schemas/commands/appellant-submission.schema.json
@@ -17,6 +17,12 @@
           "allOf": [{ "properties": { "caseType": { "const": "D" } } }, { "$ref": "appeal-has-submission.schema.json" }]
         },
         {
+          "allOf": [
+            { "properties": { "caseType": { "const": "ZP" } } },
+            { "$ref": "appeal-has-submission.schema.json" }
+          ]
+        },
+        {
           "allOf": [{ "properties": { "caseType": { "const": "W" } } }, { "$ref": "appeal-s78-submission.schema.json" }]
         },
         {

--- a/schemas/commands/lpa-questionnaire.schema.json
+++ b/schemas/commands/lpa-questionnaire.schema.json
@@ -27,6 +27,12 @@
         },
         {
           "allOf": [{ "properties": { "caseType": { "const": "D" } } }, { "$ref": "lpa-questionnaire-has.schema.json" }]
+        },
+        {
+          "allOf": [
+            { "properties": { "caseType": { "const": "ZP" } } },
+            { "$ref": "lpa-questionnaire-has.schema.json" }
+          ]
         }
       ]
     },

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -3382,6 +3382,9 @@ export interface AppellantSubmissionCommand {
         caseType?: 'D';
       } & AppellantHASSubmissionProperties)
     | ({
+        caseType?: 'ZP';
+      } & AppellantHASSubmissionProperties)
+    | ({
         caseType?: 'W';
       } & AppellantS78SubmissionProperties)
     | ({
@@ -4262,6 +4265,9 @@ export interface LPAQuestionnaireCommand {
       } & LPAQS78SubmissionProperties)
     | ({
         caseType?: 'D';
+      } & LPAQHASSubmissionProperties)
+    | ({
+        caseType?: 'ZP';
       } & LPAQHASSubmissionProperties);
   documents: {
     /**


### PR DESCRIPTION
Adds the ZP case types to the required caseType property on appellant-submission.schema.json and lpa-questionnaire.schema.json 