### PR TITLE
fix(appeals): update document type for appellant submission schema (A…

### DIFF
--- a/schemas/commands/appellant-submission.schema.json
+++ b/schemas/commands/appellant-submission.schema.json
@@ -169,7 +169,8 @@
               "groundAFeeReceipt",
               null,
               "environmentalAssessment",
-              "eiaEnvironmentalStatement"
+              "eiaEnvironmentalStatementAppellant",
+              "otherSupportingInformationAppellant"
             ],
             "description": "The type of document, used for exchange, migrations and consumption from the appeal back-office system"
           }

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -3923,7 +3923,8 @@ export interface AppellantSubmissionCommand {
       | 'groundAFeeReceipt'
       | null
       | 'environmentalAssessment'
-      | 'eiaEnvironmentalStatement';
+      | 'eiaEnvironmentalStatementAppellant'
+      | 'otherSupportingInformationAppellant';
     [k: string]: unknown;
   }[];
   /**


### PR DESCRIPTION
Rename document type from eiaEnvironmentalStatement to eiaEnvironmentalStatementAppellant to match schema. and adding new doctype to appellant-submission schema.

Missed in the first PR