### PR TITLE
fix(appeals): add type sting to reslove pySpark issue

### DIFF
--- a/schemas/appeal-s78.schema.json
+++ b/schemas/appeal-s78.schema.json
@@ -1363,7 +1363,8 @@
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/definitions/SignificantChangesAffectingApplication"
+            "$ref": "#/definitions/SignificantChangesAffectingApplication",
+            "type": "string"
           },
           "comment": {
             "type": ["string", "null"]
@@ -1379,7 +1380,8 @@
         "type": "object",
         "properties": {
           "value": {
-            "$ref": "#/definitions/SignificantChangesAffectingApplication"
+            "$ref": "#/definitions/SignificantChangesAffectingApplication",
+            "type": "string"
           },
           "comment": {
             "type": ["string", "null"]

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -1718,7 +1718,7 @@ export type AppealS78Case = (GridReference | SiteAddress) & {
    */
   significantChangesAffectingApplicationAppellant?:
     | {
-        value: SignificantChangesAffectingApplication;
+        value: 'adopted-a-new-local-plan' | 'national-policy-change' | 'court-judgement' | 'other';
         comment?: string | null;
       }[]
     | null;
@@ -1727,17 +1727,12 @@ export type AppealS78Case = (GridReference | SiteAddress) & {
    */
   significantChangesAffectingApplicationLpa?:
     | {
-        value: SignificantChangesAffectingApplication;
+        value: 'adopted-a-new-local-plan' | 'national-policy-change' | 'court-judgement' | 'other';
         comment?: string | null;
       }[]
     | null;
   [k: string]: unknown;
 };
-export type SignificantChangesAffectingApplication =
-  | 'adopted-a-new-local-plan'
-  | 'national-policy-change'
-  | 'court-judgement'
-  | 'other';
 
 export interface GridReference {
   siteGridReferenceEasting: string;


### PR DESCRIPTION
Added type:'String' to value object to fix below issue with PySpark
ValueError: Missing 'type' in schema: {'$ref': '#/definitions/SignificantChangesAffectingApplication'}