### PR TITLE
feat(appeals): remove planning obligation required in LDC

### DIFF
--- a/schemas/commands/appellant-submission.schema.json
+++ b/schemas/commands/appellant-submission.schema.json
@@ -73,7 +73,6 @@
             { "$ref": "appeals-components/appeal-common-submission.schema.json" },
             { "$ref": "appeals-components/appeal-common-planning.schema.json" },
             { "$ref": "appeals-components/appellant-procedure-preference.schema.json" },
-            { "$ref": "appeals-components/appeal-planning-obligation.submission.schema.json" },
             { "$ref": "appeals-components/appeal-ldc.submission.schema.json" }
           ]
         },

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -3904,7 +3904,6 @@ export interface AppellantSubmissionCommand {
       } & AppellantCommonSubmissionProperties &
         AppellantCommonPlanningProperties &
         AppellantProcedurePreferenceProperties &
-        PlanningObligationSpecificProperties &
         LDCSpecificProperties)
     | ({
         caseType?: 'F';

--- a/tests/appeals/commands/ldc-submission.test.js
+++ b/tests/appeals/commands/ldc-submission.test.js
@@ -63,8 +63,6 @@ const exampleLDCSubmissionSchema = {
 		appellantProcedurePreferenceDetails: 'eiusmod ex exercitation',
 		appellantProcedurePreferenceDuration: 10816414.941069126,
 		appellantProcedurePreferenceWitnessCount: -91300569.36444478,
-		planningObligation: true,
-		statusPlanningObligation: 'finalised',
 		siteUseAtTimeOfApplication: 'residential',
 		applicationMadeUnderActSection: 'existing-development'
 	},


### PR DESCRIPTION
Removes planning obligation as a required field from LDC appeal submissions

Ticket: https://pins-ds.atlassian.net/browse/A2-8114