### PR TITLE
feat(appeals):  uncouple site visit type from event date/time in appeal event schema

### DIFF
--- a/docs/appeal-event.md
+++ b/docs/appeal-event.md
@@ -13,14 +13,14 @@
 | [eventStatus](#eventstatus)                         | `string`  | Required | cannot be null | [Appeal Event](appeal-event-properties-eventstatus.md "appeal-event.schema.json#/properties/eventStatus")                         |
 | [isUrgent](#isurgent)                               | `boolean` | Required | cannot be null | [Appeal Event](appeal-event-properties-isurgent.md "appeal-event.schema.json#/properties/isUrgent")                               |
 | [eventPublished](#eventpublished)                   | `boolean` | Required | can be null    | [Appeal Event](appeal-event-properties-eventpublished.md "appeal-event.schema.json#/properties/eventPublished")                   |
-| [eventStartDateTime](#eventstartdatetime)           | `string`  | Required | cannot be null | [Appeal Event](appeal-event-properties-eventstartdatetime.md "appeal-event.schema.json#/properties/eventStartDateTime")           |
-| [eventEndDateTime](#eventenddatetime)               | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-eventenddatetime.md "appeal-event.schema.json#/properties/eventEndDateTime")               |
-| [notificationOfSiteVisit](#notificationofsitevisit) | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-notificationofsitevisit.md "appeal-event.schema.json#/properties/notificationOfSiteVisit") |
-| [addressLine1](#addressline1)                       | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-addressline1.md "appeal-event.schema.json#/properties/addressLine1")                       |
-| [addressLine2](#addressline2)                       | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-addressline2.md "appeal-event.schema.json#/properties/addressLine2")                       |
-| [addressTown](#addresstown)                         | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-addresstown.md "appeal-event.schema.json#/properties/addressTown")                         |
-| [addressCounty](#addresscounty)                     | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-addresscounty.md "appeal-event.schema.json#/properties/addressCounty")                     |
-| [addressPostcode](#addresspostcode)                 | `string`  | Required | can be null    | [Appeal Event](appeal-event-properties-addresspostcode.md "appeal-event.schema.json#/properties/addressPostcode")                 |
+| [eventStartDateTime](#eventstartdatetime)           | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-eventstartdatetime.md "appeal-event.schema.json#/properties/eventStartDateTime")           |
+| [eventEndDateTime](#eventenddatetime)               | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-eventenddatetime.md "appeal-event.schema.json#/properties/eventEndDateTime")               |
+| [notificationOfSiteVisit](#notificationofsitevisit) | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-notificationofsitevisit.md "appeal-event.schema.json#/properties/notificationOfSiteVisit") |
+| [addressLine1](#addressline1)                       | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-addressline1.md "appeal-event.schema.json#/properties/addressLine1")                       |
+| [addressLine2](#addressline2)                       | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-addressline2.md "appeal-event.schema.json#/properties/addressLine2")                       |
+| [addressTown](#addresstown)                         | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-addresstown.md "appeal-event.schema.json#/properties/addressTown")                         |
+| [addressCounty](#addresscounty)                     | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-addresscounty.md "appeal-event.schema.json#/properties/addressCounty")                     |
+| [addressPostcode](#addresspostcode)                 | `string`  | Optional | can be null    | [Appeal Event](appeal-event-properties-addresspostcode.md "appeal-event.schema.json#/properties/addressPostcode")                 |
 | Additional Properties                               | Any       | Optional | can be null    |                                                                                                                                   |
 
 ## eventId
@@ -164,6 +164,7 @@ Status of the event
 | `"link_to_enforcement"` |             |
 | `"offered"`             |             |
 | `"postponed"`           |             |
+| `"pending"`             |             |
 
 ## isUrgent
 
@@ -207,11 +208,11 @@ Event start date and time
 
 `eventStartDateTime`
 
-* is required
+* is optional
 
 * Type: `string`
 
-* cannot be null
+* can be null
 
 * defined in: [Appeal Event](appeal-event-properties-eventstartdatetime.md "appeal-event.schema.json#/properties/eventStartDateTime")
 
@@ -235,7 +236,7 @@ Event end date and time
 
 `eventEndDateTime`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -263,7 +264,7 @@ The date third-parties were informed of the site visit event
 
 `notificationOfSiteVisit`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -291,7 +292,7 @@ First line of address for the event site
 
 `addressLine1`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -315,7 +316,7 @@ Second line of address for the event site
 
 `addressLine2`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -333,7 +334,7 @@ Town / City of the event address
 
 `addressTown`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -357,7 +358,7 @@ County of the event address
 
 `addressCounty`
 
-* is required
+* is optional
 
 * Type: `string`
 
@@ -381,7 +382,7 @@ Postal code of the event address
 
 `addressPostcode`
 
-* is required
+* is optional
 
 * Type: `string`
 

--- a/pins_data_model/models/model_appeal_event.py
+++ b/pins_data_model/models/model_appeal_event.py
@@ -38,6 +38,7 @@ class EventStatus(Enum):
     link_to_enforcement = "link_to_enforcement"
     offered = "offered"
     postponed = "postponed"
+    pending = "pending"
 
 
 class AppealEvent(BaseModel):
@@ -76,25 +77,25 @@ class AppealEvent(BaseModel):
     """
     Indicates if the event has been published
     """
-    eventStartDateTime: AwareDatetime = Field(
-        ..., examples=["2023-07-27T20:30:00.000Z"]
+    eventStartDateTime: AwareDatetime | None = Field(
+        None, examples=["2023-07-27T20:30:00.000Z"]
     )
     """
     Event start date and time
     """
     eventEndDateTime: AwareDatetime | None = Field(
-        ..., examples=["2023-07-27T20:30:00.000Z"]
+        None, examples=["2023-07-27T20:30:00.000Z"]
     )
     """
     Event end date and time
     """
     notificationOfSiteVisit: AwareDatetime | None = Field(
-        ..., examples=["2023-07-27T20:30:00.000Z"]
+        None, examples=["2023-07-27T20:30:00.000Z"]
     )
     """
     The date third-parties were informed of the site visit event
     """
-    addressLine1: str | None = Field(..., examples=["96 The Avenue"])
+    addressLine1: str | None = Field(None, examples=["96 The Avenue"])
     """
     First line of address for the event site
     """
@@ -102,15 +103,15 @@ class AppealEvent(BaseModel):
     """
     Second line of address for the event site
     """
-    addressTown: str | None = Field(..., examples=["Maidstone"])
+    addressTown: str | None = Field(None, examples=["Maidstone"])
     """
     Town / City of the event address
     """
-    addressCounty: str | None = Field(..., examples=["Kent"])
+    addressCounty: str | None = Field(None, examples=["Kent"])
     """
     County of the event address
     """
-    addressPostcode: str | None = Field(..., examples=["MD21 5XY"])
+    addressPostcode: str | None = Field(None, examples=["MD21 5XY"])
     """
     Postal code of the event address
     """

--- a/schemas/appeal-event.schema.json
+++ b/schemas/appeal-event.schema.json
@@ -5,23 +5,7 @@
   "description": "Schema defining the metadata for appeal events, such as site visits, inquiries, hearings",
   "type": "object",
   "additionalProperties": true,
-  "required": [
-    "eventId",
-    "caseReference",
-    "eventType",
-    "eventName",
-    "eventStatus",
-    "isUrgent",
-    "eventPublished",
-    "eventStartDateTime",
-    "eventEndDateTime",
-    "notificationOfSiteVisit",
-    "addressLine1",
-    "addressLine2",
-    "addressTown",
-    "addressCounty",
-    "addressPostcode"
-  ],
+  "required": ["eventId", "caseReference", "eventType", "eventName", "eventStatus", "isUrgent", "eventPublished"],
   "properties": {
     "eventId": {
       "type": "string",
@@ -65,7 +49,8 @@
         "confirmed",
         "link_to_enforcement",
         "offered",
-        "postponed"
+        "postponed",
+        "pending"
       ],
       "description": "Status of the event"
     },
@@ -78,7 +63,7 @@
       "description": "Indicates if the event has been published"
     },
     "eventStartDateTime": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "date-time",
       "examples": ["2023-07-27T20:30:00.000Z"],
       "description": "Event start date and time"

--- a/src/enums.cjs
+++ b/src/enums.cjs
@@ -309,6 +309,7 @@ const APPEAL_EVENT_STATUS = Object.freeze({
   LINK_TO_ENFORCEMENT: 'link_to_enforcement',
   NEW_RESCHEDULED: 'new_rescheduled',
   OFFERED: 'offered',
+  PENDING: 'pending',
   POSTPONED: 'postponed',
   WITHDRAWN: 'withdrawn',
 });

--- a/src/enums.d.ts
+++ b/src/enums.d.ts
@@ -307,6 +307,7 @@ export const APPEAL_EVENT_STATUS = {
   LINK_TO_ENFORCEMENT: 'link_to_enforcement',
   NEW_RESCHEDULED: 'new_rescheduled',
   OFFERED: 'offered',
+  PENDING: 'pending',
   POSTPONED: 'postponed',
   WITHDRAWN: 'withdrawn',
 } as const;

--- a/src/enums.js
+++ b/src/enums.js
@@ -307,6 +307,7 @@ export const APPEAL_EVENT_STATUS = Object.freeze({
   LINK_TO_ENFORCEMENT: 'link_to_enforcement',
   NEW_RESCHEDULED: 'new_rescheduled',
   OFFERED: 'offered',
+  PENDING: 'pending',
   POSTPONED: 'postponed',
   WITHDRAWN: 'withdrawn',
 });

--- a/src/index.cjs
+++ b/src/index.cjs
@@ -390,6 +390,7 @@ const APPEAL_EVENT_STATUS = Object.freeze({
   LINK_TO_ENFORCEMENT: 'link_to_enforcement',
   NEW_RESCHEDULED: 'new_rescheduled',
   OFFERED: 'offered',
+  PENDING: 'pending',
   POSTPONED: 'postponed',
   WITHDRAWN: 'withdrawn',
 });

--- a/src/schemas.d.ts
+++ b/src/schemas.d.ts
@@ -292,7 +292,8 @@ export interface AppealEvent {
     | 'confirmed'
     | 'link_to_enforcement'
     | 'offered'
-    | 'postponed';
+    | 'postponed'
+    | 'pending';
   /**
    * Indicates if the event is urgent
    */
@@ -304,35 +305,35 @@ export interface AppealEvent {
   /**
    * Event start date and time
    */
-  eventStartDateTime: string;
+  eventStartDateTime?: string | null;
   /**
    * Event end date and time
    */
-  eventEndDateTime: string | null;
+  eventEndDateTime?: string | null;
   /**
    * The date third-parties were informed of the site visit event
    */
-  notificationOfSiteVisit: string | null;
+  notificationOfSiteVisit?: string | null;
   /**
    * First line of address for the event site
    */
-  addressLine1: string | null;
+  addressLine1?: string | null;
   /**
    * Second line of address for the event site
    */
-  addressLine2: string | null;
+  addressLine2?: string | null;
   /**
    * Town / City of the event address
    */
-  addressTown: string | null;
+  addressTown?: string | null;
   /**
    * County of the event address
    */
-  addressCounty: string | null;
+  addressCounty?: string | null;
   /**
    * Postal code of the event address
    */
-  addressPostcode: string | null;
+  addressPostcode?: string | null;
   [k: string]: unknown;
 }
 

--- a/tests/appeals/appeal-event.test.js
+++ b/tests/appeals/appeal-event.test.js
@@ -53,6 +53,22 @@ describe(schema, () => {
 		assert.strictEqual(validationResult, true);
 	});
 
+	it('should allow eventStatus to be pending, eventStartDateTime to be null, and address fields to be omitted', () => {
+		const test = {
+			eventId: 'ipsum ut proident Ut',
+			caseReference: 'irure dolore in exercitation elit',
+			eventType: 'site_visit_accompanied',
+			eventName: 'minim anim',
+			eventStatus: 'pending',
+			isUrgent: true,
+			eventPublished: false,
+			eventStartDateTime: null
+		};
+
+		const validationResult = ajv.validate(schema, test);
+		assert.strictEqual(validationResult, true);
+	});
+
 	it('should allow additional props', () => {
 		const test = structuredClone(event);
 		test.test = 1; // additional unknown prop allowed


### PR DESCRIPTION
Updates:
Updated appeal-event.schema.json to make eventStartDateTime nullable and address fields optional.
Added pending status to eventStatus enum.
Regenerated Python models (pins_data_model/models/model_appeal_event.py), JS/TS types, enums, and documentation.

Testing:
Added a validation test case in appeal-event.test.js verifying that eventStatus: 'pending' works with eventStartDateTime: null and address fields omitted.